### PR TITLE
docs(readme): update to explain that it worked once using the correct…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Main purpose here is to get `semantic-release` working.
 * ~Not triggered when pushing direct to `master`.~
     * Actually, it does.
     * Stuck at `The commit should not trigger a release`, probably because of the commit messages not matching the right format, something like `fix(pencil): stop graphite breaking when too much pressure applied`.
+    * OK, got to `v0.0.5` automatically with the commit message done properly!
 * Trying with all sorts of updated settings and token authentication.
 * Trying `language: minimal`.


### PR DESCRIPTION
… `type` in the commit message